### PR TITLE
Adding Make instructions in README 

### DIFF
--- a/Makesalt
+++ b/Makesalt
@@ -4,7 +4,7 @@ DIR_OBJECT = .
 DIR_TARGET = .
 
 SOURCES = salt.c
-TARGET = salt
+TARGET = actprep
 
 CC = gcc
 #CFLAGS = -g -O3 -fno-common -std=gnu99 -Wall -D_REENTRANT

--- a/README
+++ b/README
@@ -1,3 +1,16 @@
+Getting started
+---------------
+
+git clone git@github.com:aerospike/act.git
+cd act
+make
+make -f Makesalt
+
+This will create 2 binaries, act and actprep
+
+* actprep:This executable will basically zero’s out the drives and fills it up with random data(Salting). Basically to reproduce a normal production state.
+* act: The primary executable.
+
 Test Process Overview
 ---------------------
 

--- a/runact
+++ b/runact
@@ -1,6 +1,11 @@
+#!/bin/bash
+####
+# Usage: ./runact device actconfig resultfile
+# e.g. ./runact /dev/sdc actconfig_1x.txt sdc-1x-intel320.txt
+####
 echo "Zero and salt drive"
 date
-sudo ./salt $1
+sudo ./actprep $1
 echo "Start act"
 date
 sudo ./act $2 > $3


### PR DESCRIPTION
Adding Make instructions in README and minor edit to Makesalt to output actprep as README suggests and also adding header to runact script so the its easy to understand how its run. 
