### PR TITLE
Update act_latency.py

### DIFF
--- a/latency_calc/act_latency.py
+++ b/latency_calc/act_latency.py
@@ -350,8 +350,8 @@ except getopt.GetoptError, err:
 # Default values for arguments:
 arg_log = None
 arg_slice = 3600
-arg_num_buckets = 3
-arg_every_nth = 3
+arg_num_buckets = 7
+arg_every_nth = 1
 arg_extra = False
 
 # Set the arguments:


### PR DESCRIPTION
Changed the default number of buckets from 3 to 7 and "every nth" to 1. This allows for more time granularity in the analysis.
