### PR TITLE
change output milliseconds to microseconds

### DIFF
--- a/clock.c
+++ b/clock.c
@@ -35,6 +35,13 @@ cf_getms() {
 }	
 
 cf_clock
+cf_getus() {
+	struct timespec ts;
+	clock_gettime( CLOCK_MONOTONIC, &ts);
+	return ( TIMESPEC_TO_US (ts) );
+}	
+
+cf_clock
 cf_clock_getabsolute() {
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);

--- a/clock.h
+++ b/clock.h
@@ -52,6 +52,16 @@ TIMESPEC_TO_MS( struct timespec ts )
     return ( r1 + r2 );
 }
 
+inline static uint64_t
+TIMESPEC_TO_US( struct timespec ts )
+{
+    uint64_t r1 = ts.tv_nsec;
+    r1 /= 1000;
+    uint64_t r2 = ts.tv_sec;
+    r2 *= 1000000;
+    return ( r1 + r2 );
+}
+
 inline static void
 TIMESPEC_ADD_MS(struct timespec *ts, uint64_t ms)
 {

--- a/histogram.c
+++ b/histogram.c
@@ -122,17 +122,17 @@ void histogram_dump(histogram* h, const char* p_tag) {
 	}
 }
 
-void histogram_insert_data_point(histogram* h, uint64_t delta_ms) {
+void histogram_insert_data_point(histogram* h, uint64_t delta_us) {
 	cf_atomic_int_incr(&h->n_counts);
 
-	int index = bits_find_last_set_64(delta_ms);
+	int index = bits_find_last_set_64(delta_us);
 
 	if (index < 0) {
 		index = 0;
 	}
 
-	if ((int64_t)delta_ms < 0) {
-	    // Need to investigate why in some cases start is a couple of ms greater than end
+	if ((int64_t)delta_us < 0) {
+	    // Need to investigate why in some cases start is a couple of us greater than end
 		// Could it be rounding error (usually the difference is 1 but sometimes I have seen 2
 	    // fprintf(stdout, "start = %"PRIu64" > end = %"PRIu64"", start, end);
 		index = 0;

--- a/queue.c
+++ b/queue.c
@@ -271,12 +271,12 @@ cf_queue_push_head(cf_queue *q, void *ptr)
 
 
 /* cf_queue_pop
- * if ms_wait < 0, wait forever
- * if ms_wait = 0, don't wait at all
- * if ms_wait > 0, wait that number of ms
+ * if us_wait < 0, wait forever
+ * if us_wait = 0, don't wait at all
+ * if us_wait > 0, wait that number of us
  * */
 int
-cf_queue_pop(cf_queue *q, void *buf, int ms_wait)
+cf_queue_pop(cf_queue *q, void *buf, int us_wait)
 {
 	if (NULL == q)
 		return(-1);
@@ -286,10 +286,10 @@ cf_queue_pop(cf_queue *q, void *buf, int ms_wait)
 		return(-1);
 
 	struct timespec tp;
-	if (ms_wait > 0) {
+	if (us_wait > 0) {
 		clock_gettime( CLOCK_REALTIME, &tp); 
-		tp.tv_sec += ms_wait / 1000;
-		tp.tv_nsec += (ms_wait % 1000) * 1000000;
+		tp.tv_sec += us_wait / 1000000;
+		tp.tv_nsec += (us_wait % 1000000) * 1000000;
 		if (tp.tv_nsec > 1000000000) {
 			tp.tv_nsec -= 1000000000;
 			tp.tv_sec++;
@@ -302,10 +302,10 @@ cf_queue_pop(cf_queue *q, void *buf, int ms_wait)
 	 * waiting thread will be awakened... */
 	if (q->threadsafe) {
 		while (CF_Q_EMPTY(q)) {
-			if (CF_QUEUE_FOREVER == ms_wait) {
+			if (CF_QUEUE_FOREVER == us_wait) {
 				pthread_cond_wait(&q->CV, &q->LOCK);
 			}
-			else if (CF_QUEUE_NOWAIT == ms_wait) {
+			else if (CF_QUEUE_NOWAIT == us_wait) {
 				pthread_mutex_unlock(&q->LOCK);
 				return(CF_QUEUE_EMPTY);
 			}
@@ -560,16 +560,16 @@ cf_queue_priority_push(cf_queue_priority *q, void *ptr, int pri)
 }
 
 int 
-cf_queue_priority_pop(cf_queue_priority *q, void *buf, int ms_wait)
+cf_queue_priority_pop(cf_queue_priority *q, void *buf, int us_wait)
 {
 	if (q->threadsafe && (0 != pthread_mutex_lock(&q->LOCK)))
 			return(-1);
 
 	struct timespec tp;
-	if (ms_wait > 0) {
+	if (us_wait > 0) {
 		clock_gettime( CLOCK_REALTIME, &tp); 
-		tp.tv_sec += ms_wait / 1000;
-		tp.tv_nsec += (ms_wait % 1000) * 1000000;
+		tp.tv_sec += us_wait / 1000000;
+		tp.tv_nsec += (us_wait % 1000000) * 1000000;
 		if (tp.tv_nsec > 1000000000) {
 			tp.tv_nsec -= 1000000000;
 			tp.tv_sec++;
@@ -578,10 +578,10 @@ cf_queue_priority_pop(cf_queue_priority *q, void *buf, int ms_wait)
 
 	if (q->threadsafe) {
 		while (CF_Q_PRI_EMPTY(q)) {
-			if (CF_QUEUE_FOREVER == ms_wait) {
+			if (CF_QUEUE_FOREVER == us_wait) {
 				pthread_cond_wait(&q->CV, &q->LOCK);
 			}
-			else if (CF_QUEUE_NOWAIT == ms_wait) {
+			else if (CF_QUEUE_NOWAIT == us_wait) {
 				pthread_mutex_unlock(&q->LOCK);
 				return(CF_QUEUE_EMPTY);
 			}

--- a/queue.h
+++ b/queue.h
@@ -80,12 +80,12 @@ extern int cf_queue_sz(cf_queue *q);
 #define CF_QUEUE_ERR -1
 #define CF_QUEUE_OK 0
 
-// mswait < 0 wait forever
-// mswait == 0 wait not at all
-// mswait > 0 wait that number of ms
+// uswait < 0 wait forever
+// uswait == 0 wait not at all
+// uswait > 0 wait that number of us
 #define CF_QUEUE_FOREVER -1
 #define CF_QUEUE_NOWAIT 0
-extern int cf_queue_pop(cf_queue *q, void *buf, int mswait);
+extern int cf_queue_pop(cf_queue *q, void *buf, int uswait);
 
 // Queue Reduce
 // Run the entire queue, calling the callback, with the lock held
@@ -130,7 +130,7 @@ typedef struct cf_queue_priority_s {
 extern cf_queue_priority *cf_queue_priority_create(size_t elementsz, bool threadsafe);
 extern void cf_queue_priority_destroy(cf_queue_priority *q);
 extern int cf_queue_priority_push(cf_queue_priority *q, void *ptr, int pri);
-extern int cf_queue_priority_pop(cf_queue_priority *q, void *buf, int mswait);
+extern int cf_queue_priority_pop(cf_queue_priority *q, void *buf, int uswait);
 extern int cf_queue_priority_sz(cf_queue_priority *q);
 
 


### PR DESCRIPTION
create results to display with microseconds instead of milliseconds, this adds better support for low latency devices with a better distribution.
