### PR TITLE
act_config_helper config filenames much more descriptive

### DIFF
--- a/act_config_helper.py
+++ b/act_config_helper.py
@@ -139,7 +139,9 @@ class RunCommand(cmd.Cmd):
 					else:
 						load_tag = 'non-standard'
 						filename_load_tag = str(read_reqs_per_sec / no_of_devices) + 'r' + str(write_reqs_per_sec / no_of_devices) + 'w'
-					actfile = 'actconfig_' + filename_load_tag + '_' + str(no_of_devices) + 'd.txt'
+					devices = device_names.split(',')
+					device_names = '_'.join([ d.split('/')[-1] for d in devices ])
+					actfile = "config_%s_%dh_%s.txt"%(filename_load_tag,tds,device_names)
 					try:
 						act_file_fd = open(actfile, "wb")
 						act_file_fd.write('##########\n')


### PR DESCRIPTION
instead of `actconfig_4x_1d.txt`, it is now `config_4x_24h_sdb.txt`.

Additional info at a glance in filename:
- Instead of device count, a list of device names (1d was ambiguous for duration)
- duration in hours 
- Also helps in tab completion due to not starting with `act`
