### PR TITLE
Extend sleep_us to int64_t

### DIFF
--- a/act.c
+++ b/act.c
@@ -471,7 +471,7 @@ static void* run_large_block_reads(void* pv_device) {
 			((double)(count * 1000000 * g_num_devices) /
 				g_large_block_ops_per_sec);
 
-		int sleep_us = (int)(target_us - (cf_getus() - start_us));
+		int64_t sleep_us = (int)(target_us - (cf_getus() - start_us));
 
 		if (sleep_us > 0) {
 			usleep((uint32_t)sleep_us);
@@ -509,7 +509,7 @@ static void* run_large_block_writes(void* pv_device) {
 			((double)(count * 1000000 * g_num_devices) /
 				g_large_block_ops_per_sec);
 
-		int sleep_us = (int)(target_us - (cf_getus() - start_us));
+		int64_t sleep_us = (int)(target_us - (cf_getus() - start_us));
 
 		if (sleep_us > 0) {
 			usleep((uint32_t)sleep_us);


### PR DESCRIPTION
Extend sleep_us to 64 bits to prevent inversion from negative to positive values in cases where target_us increases slower than cf_getus().