### PR TITLE
Add Support for Compressible Data Generation

### DIFF
--- a/src/common/random.c
+++ b/src/common/random.c
@@ -108,6 +108,42 @@ rand_fill(uint8_t* p_buffer, uint32_t size)
 	return true;
 }
 
+//------------------------------------------------
+// Fill a buffer with target compression ratio.
+//
+
+bool
+comp_fill(uint8_t* p_buffer, uint32_t size, uint32_t compress_percent)
+{
+	uint64_t* p_write = (uint64_t*)p_buffer; 	
+	uint64_t* p_end = (uint64_t*)(p_buffer + size);
+	// ... relies on size being a multiple of 8, which it will be.
+	const uint32_t interval_size = 512;   // Space out zero runs at this interval
+	const uint32_t interval_num = size / interval_size;
+	const uint32_t z_len = (((100 - compress_percent) * interval_size) / 100) / sizeof(uint64_t);
+	const uint32_t r_len = (interval_size / sizeof(uint64_t)) - z_len;
+	// ... data must be in interval_size units to achieve target compression ratio
+	int32_t i, z, r;
+
+	for (i = 0; i < interval_num; i++) {
+		z = z_len;
+		while (z--) {
+			*p_write++ = 0;
+		}
+		r = r_len;
+		while (r--) {
+			*p_write++ = xorshift128plus();
+		}
+	}
+
+	while (p_write < p_end) {
+		*p_write++ = xorshift128plus();
+	}
+
+	return true;
+}
+
+
 
 //==========================================================
 // Local helpers.

--- a/src/common/random.c
+++ b/src/common/random.c
@@ -143,8 +143,6 @@ comp_fill(uint8_t* p_buffer, uint32_t size, uint32_t compress_percent)
 	return true;
 }
 
-
-
 //==========================================================
 // Local helpers.
 //

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -41,3 +41,5 @@ void rand_seed_thread();
 uint32_t rand_32();
 uint64_t rand_64();
 bool rand_fill(uint8_t* p_buffer, uint32_t size);
+bool comp_fill(uint8_t* p_buffer, uint32_t size, uint32_t compress_percent);
+

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -42,4 +42,3 @@ uint32_t rand_32();
 uint64_t rand_64();
 bool rand_fill(uint8_t* p_buffer, uint32_t size);
 bool comp_fill(uint8_t* p_buffer, uint32_t size, uint32_t compress_percent);
-

--- a/src/storage/act_storage.c
+++ b/src/storage/act_storage.c
@@ -1047,7 +1047,12 @@ static void
 write_and_report(trans_req* write_req, uint8_t* buf)
 {
 	// Salt each record.
-	rand_fill(buf, write_req->size);
+	if (g_scfg.compress_percent < 100) {
+		comp_fill(buf, write_req->size, g_scfg.compress_percent);
+	}
+	else {
+		rand_fill(buf, write_req->size);
+	}
 
 	uint64_t raw_start_time = get_ns();
 	uint64_t stop_time = write_to_device(write_req->dev, write_req->offset,
@@ -1070,7 +1075,12 @@ static void
 write_and_report_large_block(device* dev, uint8_t* buf, uint64_t count)
 {
 	// Salt the block each time.
-	rand_fill(buf, g_scfg.large_block_ops_bytes);
+	if (g_scfg.compress_percent < 100) {
+		comp_fill(buf, g_scfg.large_block_ops_bytes, g_scfg.compress_percent);
+	}
+	else {
+		rand_fill(buf, g_scfg.large_block_ops_bytes);
+	}
 
 	uint64_t offset = random_large_block_offset(dev);
 	uint64_t start_time = get_ns();

--- a/src/storage/cfg_storage.c
+++ b/src/storage/cfg_storage.c
@@ -329,7 +329,7 @@ check_configuration()
 		configuration_error(TAG_COMMIT_MIN_BYTES);
 		return false;
 	}
-	if (g_scfg.compress_percent > 100 ) {
+	if (g_scfg.compress_percent > 100) {
 		configuration_error(TAG_COMPRESS_PERCENT);
 		return false;
 	}
@@ -504,6 +504,8 @@ echo_configuration()
 			g_scfg.max_lag_usec / 1000000);
 	fprintf(stdout, "%s: %s\n", TAG_SCHEDULER_MODE,
 			g_scfg.scheduler_mode);
+	fprintf(stdout, "%s: %" PRIu32 "\n", TAG_COMPRESS_PERCENT,
+			g_scfg.compress_percent);
 
 	fprintf(stdout, "\nDERIVED CONFIGURATION\n");
 

--- a/src/storage/cfg_storage.c
+++ b/src/storage/cfg_storage.c
@@ -69,6 +69,7 @@ static const char TAG_TOMB_RAIDER_SLEEP_USEC[]  = "tomb-raider-sleep-usec";
 static const char TAG_MAX_REQS_QUEUED[]         = "max-reqs-queued";
 static const char TAG_MAX_LAG_SEC[]             = "max-lag-sec";
 static const char TAG_SCHEDULER_MODE[]          = "scheduler-mode";
+static const char TAG_COMPRESS_PERCENT[]        = "compress-percent";
 
 #define RBLOCK_SIZE 16 // must be power of 2
 
@@ -97,7 +98,8 @@ storage_cfg g_scfg = {
 		.defrag_lwm_pct = 50,
 		.max_reqs_queued = 100000,
 		.max_lag_usec = 1000000 * 10,
-		.scheduler_mode = "noop"
+		.scheduler_mode = "noop",
+		.compress_percent = 100
 };
 
 
@@ -226,6 +228,9 @@ storage_configure(int argc, char* argv[])
 		else if (strcmp(tag, TAG_SCHEDULER_MODE) == 0) {
 			g_scfg.scheduler_mode = parse_scheduler_mode();
 		}
+		else if (strcmp(tag, TAG_COMPRESS_PERCENT) == 0) {
+			g_scfg.compress_percent = parse_uint32();
+		}
 		else {
 			fprintf(stdout, "ERROR: ignoring unknown config item '%s'\n", tag);
 		}
@@ -322,6 +327,10 @@ check_configuration()
 			(g_scfg.commit_min_bytes > g_scfg.large_block_ops_bytes ||
 			! is_power_of_2(g_scfg.commit_min_bytes))) {
 		configuration_error(TAG_COMMIT_MIN_BYTES);
+		return false;
+	}
+	if (g_scfg.compress_percent > 100 ) {
+		configuration_error(TAG_COMPRESS_PERCENT);
 		return false;
 	}
 

--- a/src/storage/cfg_storage.h
+++ b/src/storage/cfg_storage.h
@@ -76,6 +76,7 @@ typedef struct storage_cfg_s {
 	uint32_t write_req_threads;
 	double large_block_reads_per_sec;
 	double large_block_writes_per_sec;
+	uint32_t compress_percent;
 } storage_cfg;
 
 


### PR DESCRIPTION
**Summary**
This pull requests adds a compress-percent option that allows ACT to send data with a specified target compression ratio for storage workloads. The compress-percent option works similar to the buffer_compress_percentage option in FIO. For example, setting compress-percent to 40 will configure ACT to send data that should compress to 40% of its original size. The default compress-percent value is 100, corresponding to fully random data (not compressible). Values greater than 100 are not permitted. Similar to FIO, the data is made compressible by adding runs of zeros to random data. The runs of zeros are added at 512 byte intervals in the buffer in order to prevent de-duplication or zeros truncation from skewing the compression ratio. Because run-length encoding techniques provide virtually all of the compression for the generated data pattern, similar compression ratios should be observed for most common algorithms (gzip, LZ4, Snappy, etc.).

**Motivation**
Some SSDs support in-line compression. In-line compression can reduce tail latency by lowering the amount of write-to-read interference within the SSD. By providing an option within ACT to send compressible data, one can measure the effects of compression on tail latency under different workload assumptions.