### PR TITLE
Disable defrag reads when defrag-lwm-pct is 0.

### DIFF
--- a/src/storage/cfg_storage.c
+++ b/src/storage/cfg_storage.c
@@ -387,11 +387,11 @@ derive_configuration()
         double tmp_large_block_writes_sec = original_write_rate_in_large_blocks_per_sec *
                         defrag_write_amplification;
         
-	if(g_scfg.defrag_lwm_pct == 0 && g_scfg.disable_defrag == true) {
+	if(g_scfg.defrag_lwm_pct == 0 && g_scfg.defrag_disable) {
 	        // Set large block reads to 0
                 g_scfg.large_block_reads_per_sec = 0;
         } else {
-                g_scfg.large_block_reads_per_sec = tmp_large_block_writes_sec
+                g_scfg.large_block_reads_per_sec = tmp_large_block_writes_sec;
         }
 
 	if (g_scfg.commit_to_device) {
@@ -504,6 +504,8 @@ echo_configuration()
 			g_scfg.defrag_lwm_pct);
 	fprintf(stdout, "%s: %" PRIu32 "\n", TAG_COMPRESS_PCT,
 			g_scfg.compress_pct);
+        fprintf(stdout, "%s: %s\n", TAG_DEFRAG_DISABLE,
+                        g_scfg.defrag_disable ? "yes" : "no");
 	fprintf(stdout, "%s: %s\n", TAG_DISABLE_ODSYNC,
 			g_scfg.disable_odsync ? "yes" : "no");
 	fprintf(stdout, "%s: %s\n", TAG_COMMIT_TO_DEVICE,

--- a/src/storage/cfg_storage.h
+++ b/src/storage/cfg_storage.h
@@ -59,6 +59,7 @@ typedef struct storage_cfg_s {
 	uint32_t update_pct;
 	uint32_t defrag_lwm_pct;
 	uint32_t compress_pct;
+        bool defrag_disable;            // Added to disable large block reads, when defrag_lwm_pct = 0
 	bool disable_odsync;
 	bool commit_to_device;
 	uint32_t commit_min_bytes;


### PR DESCRIPTION
Disable the impact of defragmentation on reads.

It seems like setting the property defrag-lwm-pct to 0 is not disabling large block reads. 
So, the property defrag-disable has been introduced to disable large block reads, when defrag-lwm-pct is set to 0.

It is desirable control this behavior using only a single property, which is defrag-lwm-pct. Which means that the number of defrag reads vs writes would need to be be adjusted and all cases would need to be handled accordingly.

The PR only illustrates the need for defrag-lwm-pct behavior to change.